### PR TITLE
Delete alarms by rule id

### DIFF
--- a/Services.Test/AlarmsTest.cs
+++ b/Services.Test/AlarmsTest.cs
@@ -1,0 +1,226 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
+using Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services;
+using Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services.Diagnostics;
+using Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services.Models;
+using Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services.Runtime;
+using Moq;
+using Newtonsoft.Json;
+using Services.Test.helpers;
+using Xunit;
+
+namespace Services.Test
+{
+    public class AlarmsTest
+    {
+        private readonly Mock<IStorageClient> storageClient;
+        private readonly Mock<ILogger> logger;
+        private readonly IAlarms alarms;
+
+        public AlarmsTest()
+        {
+            var servicesConfig = new ServicesConfig
+            {
+                AlarmsConfig = new AlarmsConfig("database", "collection", 3, 50, 1000)
+            };
+            this.storageClient = new Mock<IStorageClient>();
+            this.logger = new Mock<ILogger>();
+            this.alarms = new Alarms(servicesConfig, this.storageClient.Object, this.logger.Object);
+        }
+
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public void BasicDeleteByRule()
+        {
+            // Arrange
+            Document d1 = new Document
+            {
+                Id = "test"
+            };
+
+            this.SetUpStorageClientQueryResults(new List<Document> { d1 });
+
+            this.storageClient
+                .Setup(x => x.DeleteDocumentAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .Returns(Task.FromResult(d1));
+            Guid guid = Guid.NewGuid();
+
+            // Act
+            this.alarms.StartDeleteByRule("test", null, null, null, 0, 1000, new string[0], guid).Wait();
+
+            // Assert
+            this.storageClient.Verify(x => x.DeleteDocumentAsync("database", "collection", "test"), Times.Once);
+            this.storageClient.Verify(x => x.UpsertDocumentAsync("database", "collection", It.IsAny<DeleteStatus>()), Times.AtLeast(3));
+
+            this.logger.Verify(l => l.Error(It.IsAny<string>(), It.IsAny<Func<object>>()), Times.Never);
+            this.logger.Verify(l => l.Warn(It.IsAny<string>(), It.IsAny<Func<object>>()), Times.Never);
+        }
+
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public void DeleteByRuleTransientFailure()
+        {
+            // Arrange
+            Document d1 = new Document
+            {
+                Id = "test"
+            };
+
+            this.SetUpStorageClientQueryResults(new List<Document> { d1 });
+
+            this.storageClient
+                .SetupSequence(x => x.DeleteDocumentAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .Throws(new Exception())
+                .Returns(Task.FromResult(d1));
+            Guid guid = Guid.NewGuid();
+
+            // Act
+            this.alarms.StartDeleteByRule("test", null, null, null, 0, 1000, new string[0], guid).Wait();
+
+            // Assert
+            this.storageClient.Verify(x => x.DeleteDocumentAsync("database", "collection", "test"), Times.Exactly(2));
+            this.storageClient.Verify(x => x.UpsertDocumentAsync("database", "collection", It.IsAny<DeleteStatus>()), Times.AtLeast(3));
+
+            this.logger.Verify(l => l.Error(It.IsAny<string>(), It.IsAny<Func<object>>()), Times.Never);
+            this.logger.Verify(l => l.Warn(It.IsAny<string>(), It.IsAny<Func<object>>()), Times.Once);
+        }
+
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public void DeleteByRuleFailsAfter3Exceptions()
+        {
+            // Arrange
+            Document d1 = new Document
+            {
+                Id = "test"
+            };
+
+            this.SetUpStorageClientQueryResults(new List<Document> { d1 });
+
+            this.storageClient
+                .SetupSequence(x => x.DeleteDocumentAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .Throws(new Exception())
+                .Throws(new Exception())
+                .Throws(new Exception());
+
+            Guid guid = Guid.NewGuid();
+
+            // Act
+            this.alarms.StartDeleteByRule("test", null, null, null, 0, 1000, new string[0], guid).Wait();
+
+            // Assert
+            this.storageClient.Verify(x => x.DeleteDocumentAsync("database", "collection", "test"), Times.Exactly(3));
+            this.storageClient.Verify(x => x.UpsertDocumentAsync("database", "collection", It.IsAny<DeleteStatus>()), Times.AtLeast(3));
+
+            this.logger.Verify(l => l.Error(It.IsAny<string>(), It.IsAny<Func<object>>()), Times.Exactly(2));
+            this.logger.Verify(l => l.Warn(It.IsAny<string>(), It.IsAny<Func<object>>()), Times.Exactly(2));
+        }
+
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public void GetDeleteStatusIfCompleted()
+        {
+            // Arrange
+            DateTime timestamp = new DateTime(2018, 6, 4, 16, 40, 0, DateTimeKind.Utc);
+
+            Document document = this.CreateFakeDocument("id", timestamp, "Success", 20);
+            this.SetUpStorageClientQueryResults(new List<Document> { document });
+
+            // Act
+            var result = this.alarms.GetDeleteByRuleStatus("id");
+            DeleteStatus status = JsonConvert.DeserializeObject<DeleteStatus>(result);
+
+            // Assert
+            Assert.Equal("Success", status.Status);
+            Assert.Equal(20, status.RecordsDeleted);
+            Assert.Equal(timestamp, status.Timestamp);
+            Assert.Equal("id", status.Id);
+
+            this.VerifyNoErrorsOrWarnings();
+        }
+
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public void GetDeleteStatusIfInProgressOutOfDate()
+        {
+            // Arrange
+            DateTime timestamp = DateTime.UtcNow.Subtract(TimeSpan.FromDays(1));
+            Document document = this.CreateFakeDocument("id", timestamp, "In Progress", 20);
+            List<Document> documentResults = new List<Document>
+            {
+                document
+            };
+
+            this.SetUpStorageClientQueryResults(documentResults);
+
+            // Act
+            var result = this.alarms.GetDeleteByRuleStatus("id");
+            DeleteStatus status = JsonConvert.DeserializeObject<DeleteStatus>(result);
+
+            // Assert
+            Assert.Equal("Unknown", status.Status);
+            Assert.Null(status.Timestamp);
+            Assert.Equal("id", status.Id);
+            Assert.Null(status.RecordsDeleted);
+
+            this.VerifyNoErrorsOrWarnings();
+        }
+
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public void GetDeleteStatusIfNoRecord()
+        {
+            // Arrange
+            List<Document> documentResults = new List<Document>();
+            this.SetUpStorageClientQueryResults(documentResults);
+
+            // Act
+            var result = this.alarms.GetDeleteByRuleStatus("id");
+            DeleteStatus status = JsonConvert.DeserializeObject<DeleteStatus>(result);
+
+            // Assert
+            Assert.Equal("Unknown", status.Status);
+            Assert.Null(status.Timestamp);
+            Assert.Equal("id", status.Id);
+            Assert.Null(status.RecordsDeleted);
+
+            this.VerifyNoErrorsOrWarnings();
+        }
+
+        private Document CreateFakeDocument(string id, DateTime timestamp, string status, int recordsDeleted)
+        {
+            Document document = new Document();
+            document.SetPropertyValue("Status", status);
+            document.Id = id;
+            document.SetPropertyValue("Timestamp", timestamp);
+            document.SetPropertyValue("RecordsDeleted", recordsDeleted);
+            return document;
+        }
+
+        private void SetUpStorageClientQueryResults(List<Document> documentResults)
+        {
+            this.storageClient.Setup(x => x.QueryDocuments(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<FeedOptions>(),
+                    It.IsAny<string>(),
+                    It.IsAny<int>(),
+                    It.IsAny<int>()))
+                .Returns(documentResults);
+        }
+
+        private void VerifyNoErrorsOrWarnings()
+        {
+            this.logger.Verify(l => l.Error(It.IsAny<string>(), It.IsAny<Func<object>>()), Times.Never);
+            this.logger.Verify(l => l.Warn(It.IsAny<string>(), It.IsAny<Func<object>>()), Times.Never);
+        }
+    }
+}

--- a/Services.Test/AlarmsTest.cs
+++ b/Services.Test/AlarmsTest.cs
@@ -98,8 +98,9 @@ namespace Services.Test
             // Assert
             this.storageClient.Verify(x => x.DeleteDocumentAsync("database", "collection", "test"), Times.Exactly(2));
             this.storageClient.Verify(x => x.UpsertDocumentAsync("database", "collection", It.IsAny<DeleteStatus>()), Times.AtLeast(3));
-            
-            this.VerifyNoErrorsOrWarnings();
+
+            this.logger.Verify(l => l.Error(It.IsAny<string>(), It.IsAny<Func<object>>()), Times.Never);
+            this.logger.Verify(l => l.Warn(It.IsAny<string>(), It.IsAny<Func<object>>()), Times.Exactly(1));
         }
 
         /**

--- a/Services/Alarms.cs
+++ b/Services/Alarms.cs
@@ -2,7 +2,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
@@ -41,7 +43,19 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services
             DateTimeOffset? to,
             string[] devices);
 
-            Task<Alarm> UpdateAsync(string id, string status);
+        Task<Alarm> UpdateAsync(string id, string status);
+
+        Task StartDeleteByRule(
+            string id,
+            DateTimeOffset? from,
+            DateTimeOffset? to,
+            string order,
+            int skip,
+            int? limit,
+            string[] devices,
+            Guid operationId);
+
+        string GetDeleteByRuleStatus(string id);
     }
 
     public class Alarms : IAlarms
@@ -53,6 +67,9 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services
 
         private readonly string databaseName;
         private readonly string collectionId;
+        private readonly int maxRetryCount;
+        private readonly int deleteBatchSize;
+        private readonly int deleteIntervalMsec;
 
         // constants for storage keys
         private const string MESSAGE_RECEIVED_KEY = "device.msg.received";
@@ -63,8 +80,15 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services
 
         private const string ALARM_STATUS_OPEN = "open";
         private const string ALARM_STATUS_ACKNOWLEDGED = "acknowledged";
+        private const string UNKNOWN_STATUS = "Unknown";
+        private const string SUCCESS_STATUS = "Success";
+        private const string FAILED_STATUS = "Failed";
+        private const string NOTHING_TO_DELETE_STATUS = "Nothing to Delete";
+        private const string STARTED_STATUS = "Started";
+        private const string IN_PROGRESS_STATUS = "In Progress";
 
         private const int DOC_QUERY_LIMIT = 1000;
+        private const int DELETE_STATUS_UPDATE_INTERVAL_MS = 30000;
 
         public Alarms(
             IServicesConfig config,
@@ -72,17 +96,17 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services
             ILogger logger)
         {
             this.storageClient = storageClient;
-            this.databaseName = config.AlarmsConfig.DocumentDbDatabase;
-            this.collectionId = config.AlarmsConfig.DocumentDbCollection;
+            this.databaseName = config.AlarmsConfig.StorageConfig.DocumentDbDatabase;
+            this.collectionId = config.AlarmsConfig.StorageConfig.DocumentDbCollection;
             this.log = logger;
+            this.maxRetryCount = config.AlarmsConfig.MaxRetries;
+            this.deleteBatchSize = config.AlarmsConfig.DeleteBatchSize;
+            this.deleteIntervalMsec = config.AlarmsConfig.DeleteIntervalMsec;
         }
 
         public Alarm Get(string id)
         {
-            if (Regex.IsMatch(id, INVALID_CHARACTER))
-            {
-                throw new InvalidInputException("id contains illegal characters.");
-            }
+            this.VerifyId(id);
 
             Document doc = this.GetDocumentById(id);
             return new Alarm(doc);
@@ -139,34 +163,15 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services
             int limit,
             string[] devices)
         {
-            string sql = QueryBuilder.GetDocumentsSql(
-                ALARM_SCHEMA_KEY,
-                id, RULE_ID_KEY,
-                from, MESSAGE_RECEIVED_KEY,
-                to, MESSAGE_RECEIVED_KEY,
-                order, MESSAGE_RECEIVED_KEY,
+            this.VerifyId(id);
+            List<Document> docs = this.GetListOfDocuments(
+                id,
+                from,
+                to,
+                order,
                 skip,
                 limit,
-                devices, DEVICE_ID_KEY);
-
-            if (Regex.IsMatch(id, INVALID_CHARACTER))
-            {
-                throw new InvalidInputException("id contains illegal characters.");
-            }
-
-            this.log.Debug("Created Alarm By Rule Query", () => new { sql });
-
-            FeedOptions queryOptions = new FeedOptions();
-            queryOptions.EnableCrossPartitionQuery = true;
-            queryOptions.EnableScanInQuery = true;
-
-            List<Document> docs = this.storageClient.QueryDocuments(
-                this.databaseName,
-                this.collectionId,
-                queryOptions,
-                sql,
-                skip,
-                limit);
+                devices);
 
             List<Alarm> alarms = new List<Alarm>();
             foreach (Document doc in docs)
@@ -176,6 +181,40 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services
 
             return alarms;
         }
+
+        public async Task StartDeleteByRule(
+            string id,
+            DateTimeOffset? from,
+            DateTimeOffset? to,
+            string order,
+            int skip,
+            int? limit,
+            string[] devices,
+            Guid operationId)
+        {
+            this.VerifyId(id);
+
+            DeleteStatus status = new DeleteStatus
+            {
+                Id = operationId.ToString(),
+                Status = STARTED_STATUS,
+                Timestamp = DateTime.UtcNow,
+                RecordsDeleted = 0
+            };
+
+            try
+            {
+                await this.storageClient.UpsertDocumentAsync(this.databaseName, this.collectionId, status);
+            }
+            catch (Exception e)
+            {
+                this.log.Error("Could not write initial delete status", () => new { e.Message });
+            }
+
+            await Task.Run(() => this.DeleteByRule(id, from, to, order, skip, limit, devices, operationId));
+
+        }
+
 
         public int GetCountByRule(
             string id,
@@ -209,10 +248,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services
 
         public async Task<Alarm> UpdateAsync(string id, string status)
         {
-            if (Regex.IsMatch(id, INVALID_CHARACTER))
-            {
-                throw new InvalidInputException("id contains illegal characters.");
-            }
+            this.VerifyId(id);
 
             Document document = this.GetDocumentById(id);
             document.SetPropertyValue(STATUS_KEY, status);
@@ -225,12 +261,73 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services
             return new Alarm(document);
         }
 
+        public string GetDeleteByRuleStatus(string id)
+        {
+            Document document = this.GetDocumentById(id);
+            if (document == null)
+            {
+                return this.CreateUnknownStatus(id).ToString();
+            }
+
+            DeleteStatus status = new DeleteStatus(document);
+
+            // If delete is in progress and have not seen update for 2 * update interval,
+            // report unknown status (possible service was restarted)
+            if ((status.Status.Equals(IN_PROGRESS_STATUS) || status.Status.Equals(STARTED_STATUS))
+                && status.Timestamp.HasValue
+                && DateTime.UtcNow.Subtract(status.Timestamp.Value).TotalMilliseconds > DELETE_STATUS_UPDATE_INTERVAL_MS * 2)
+            {
+                return this.CreateUnknownStatus(id).ToString();
+            }
+
+            return status.ToString();
+        }
+
+        private async Task DeleteByRule(
+            string id,
+            DateTimeOffset? from,
+            DateTimeOffset? to,
+            string order,
+            int skip,
+            int? limit,
+            string[] devices,
+            Guid operationId)
+        {
+
+            Exception exception = null;
+            int deletedCount = 0;
+            try
+            {
+                List<Document> docs = this.GetListOfDocuments(
+                    id,
+                    from,
+                    to,
+                    order,
+                    skip,
+                    limit,
+                    devices);
+
+                if (docs.Count == 0)
+                {
+                    throw new ResourceNotFoundException("No alarms found");
+                }
+
+                await this.WriteIntermediateDeleteStatus(operationId.ToString(), 0, docs.Count);
+
+                this.DeleteAlarms(docs, out deletedCount, operationId.ToString());
+            }
+            catch (Exception e)
+            {
+                this.log.Error("Exception deleting alarms", () => new { e.Message });
+                exception = e;
+            }
+            await this.WriteDeleteStatus(operationId.ToString(), deletedCount, exception);
+        }
+
+
         private Document GetDocumentById(string id)
         {
-            if (Regex.IsMatch(id, INVALID_CHARACTER))
-            {
-                throw new InvalidInputException("id contains illegal characters.");
-            }
+            this.VerifyId(id);
 
             // Retrieve the document using the DocumentClient.
             List<Document> documentList = this.storageClient.QueryDocuments(
@@ -247,6 +344,176 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services
             }
 
             return null;
+        }
+
+        private void DeleteAlarms(List<Document> alarms, out int deletedCount, string operationId)
+        {
+            Stopwatch batchStopwatch = new Stopwatch();
+            Stopwatch progressStopwatch = new Stopwatch();
+            progressStopwatch.Start();
+            deletedCount = 0;
+            for (int i = 0; i < alarms.Count / this.deleteBatchSize + 1; i++)
+            {
+                int retryCount = 0;
+                bool success = false;
+                while (!success && retryCount < this.maxRetryCount)
+                {
+                    try
+                    {
+                        int start = i * this.deleteBatchSize;
+                        int end = start + this.deleteBatchSize > alarms.Count 
+                            ? alarms.Count 
+                            : start + this.deleteBatchSize;
+                        int toDelete = end - start;
+                        Task[] taskList = new Task[toDelete];
+                        batchStopwatch.Restart();
+                        for (int j = start; j < end; j++)
+                        {
+                            taskList[j % this.deleteBatchSize] = 
+                                this.storageClient.DeleteDocumentAsync(
+                                    this.databaseName, 
+                                    this.collectionId, 
+                                    alarms[j].Id);
+                        }
+
+                        Task.WaitAll(taskList);
+                        success = true;
+                        deletedCount += toDelete;
+                        if (progressStopwatch.ElapsedMilliseconds > DELETE_STATUS_UPDATE_INTERVAL_MS)
+                        {
+                            this.WriteIntermediateDeleteStatus(operationId, deletedCount, alarms.Count - deletedCount).Wait();
+                            progressStopwatch.Restart();
+                        }
+                    }
+
+                    catch (Exception e)
+                    {
+                        retryCount++;
+                        if (retryCount == this.maxRetryCount)
+                        {
+                            this.log.Error("Failed to delete batch of alarms", () => new { e.InnerException });
+                            throw e;
+                        }
+                        else
+                        {
+                            this.log.Warn("Exception on delete", () => new { e.InnerException });
+                        }
+
+                        if (e.InnerException != null && e.InnerException.GetType() == typeof(DocumentClientException))
+                        {
+                            DocumentClientException exception = (DocumentClientException)e.InnerException;
+                            Thread.Sleep(exception.RetryAfter);
+                        }
+                    }
+                }
+
+                batchStopwatch.Stop();
+                if (batchStopwatch.ElapsedMilliseconds < this.deleteIntervalMsec)
+                {
+                    Thread.Sleep((int)(this.deleteIntervalMsec - batchStopwatch.ElapsedMilliseconds));
+                }
+            }
+        }
+
+        private List<Document> GetListOfDocuments(string id,
+            DateTimeOffset? from,
+            DateTimeOffset? to,
+            string order,
+            int skip,
+            int? limit,
+            string[] devices)
+        {
+
+            string sql = QueryBuilder.GetDocumentsSql(
+                ALARM_SCHEMA_KEY,
+                id, RULE_ID_KEY,
+                from, MESSAGE_RECEIVED_KEY,
+                to, MESSAGE_RECEIVED_KEY,
+                order, MESSAGE_RECEIVED_KEY,
+                skip,
+                limit,
+                devices, DEVICE_ID_KEY);
+
+            this.log.Debug("Created Alarm By Rule Query", () => new { sql });
+
+            FeedOptions queryOptions = new FeedOptions();
+            queryOptions.EnableCrossPartitionQuery = true;
+            queryOptions.EnableScanInQuery = true;
+
+            return this.storageClient.QueryDocuments(
+                this.databaseName,
+                this.collectionId,
+                queryOptions,
+                sql,
+                skip,
+                limit);
+        }
+
+        private void VerifyId(string id)
+        {
+            if (Regex.IsMatch(id, INVALID_CHARACTER))
+            {
+                throw new InvalidInputException("id contains illegal characters.");
+            }
+        }
+
+        private DeleteStatus CreateUnknownStatus(string id)
+        {
+            return new DeleteStatus
+            {
+                Id = id,
+                Status = UNKNOWN_STATUS
+            };
+        }
+
+        private async Task WriteDeleteStatus(string id, int deletedCount, Exception e)
+        {
+            try
+            {
+                DeleteStatus status = new DeleteStatus
+                {
+                    Id = id,
+                    RecordsDeleted = deletedCount,
+                    Timestamp = DateTime.UtcNow
+                };
+                if (e != null)
+                {
+                    status.Status = e.GetType() == typeof(ResourceNotFoundException)
+                        ? NOTHING_TO_DELETE_STATUS
+                        : FAILED_STATUS;
+                }
+                else
+                {
+                    status.Status = SUCCESS_STATUS;
+                }
+
+                await this.storageClient.UpsertDocumentAsync(this.databaseName, this.collectionId, status);
+            }
+            catch (Exception exception)
+            {
+                this.log.Error("Error writing delete status to Cosmos DB", () => new { exception.Message });
+            }
+        }
+
+        private async Task WriteIntermediateDeleteStatus(string id, int deletedCount, int toDelete)
+        {
+            try
+            {
+                DeleteStatus status = new DeleteStatus
+                {
+                    Id = id,
+                    Status = IN_PROGRESS_STATUS,
+                    Timestamp = DateTime.UtcNow,
+                    RecordsDeleted = deletedCount,
+                    RecordsLeftToDelete = toDelete
+                };
+
+                await this.storageClient.UpsertDocumentAsync(this.databaseName, this.collectionId, status);
+            }
+            catch (Exception exception)
+            {
+                this.log.Error("Error writing intermediate delete status to Cosmos DB", () => new { exception.Message });
+            }
         }
     }
 }

--- a/Services/Helpers/QueryBuilder.cs
+++ b/Services/Helpers/QueryBuilder.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Text;
 using System.Text.RegularExpressions;
-using Microsoft.Azure.Amqp;
 using Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services.Exceptions;
 
 namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services.Helpers
@@ -22,13 +21,20 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services.Helpers
             string toProperty,
             string order,
             string orderProperty,
-            int skip,
-            int limit,
+            int? skip,
+            int? limit,
             string[] devices,
             string devicesProperty)
         {
             var queryBuilder = new StringBuilder();
-            queryBuilder.Append("SELECT TOP " + (skip + limit) + " * FROM c WHERE (c[`doc.schema`] = `" + schemaName + "`");
+            if (skip.HasValue && limit.HasValue)
+            {
+                queryBuilder.Append("SELECT TOP " + (skip + limit) + " * FROM c WHERE (c[`doc.schema`] = `" + schemaName + "`");
+            }
+            else
+            {
+                queryBuilder.Append("SELECT * FROM c WHERE (c[`doc.schema`] = `" + schemaName + "`");
+            }
 
             if (devices.Length > 0)
             {
@@ -76,7 +82,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services.Helpers
             string[] devices,
             string devicesProperty,
             string[] filterValues,
-            string filterProperty) 
+            string filterProperty)
         {
             var validateDeviceIds = string.Join(",", devices);
             var validateFilters = string.Join(",", filterValues);

--- a/Services/Models/DeleteStatus.cs
+++ b/Services/Models/DeleteStatus.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Azure.Documents;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services.Models
+{
+    public class DeleteStatus
+    {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; set; } = string.Empty;
+        public string Status { get; set; }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public int? RecordsDeleted { get; set; }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public DateTime? Timestamp { get; set; }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public int? RecordsLeftToDelete { get; set; }
+        
+        public DeleteStatus() { }
+
+        public DeleteStatus(Document doc)
+        {
+            if (doc != null)
+            {
+                this.Id = doc.Id;
+                this.Status = doc.GetPropertyValue<string>("Status");
+                this.RecordsDeleted = doc.GetPropertyValue<int?>("RecordsDeleted");
+                this.RecordsLeftToDelete = doc.GetPropertyValue<int?>("RecordsLeftToDelete");
+                this.Timestamp = doc.GetPropertyValue<DateTime?>("Timestamp");
+            }
+        }
+
+        public override string ToString()
+        {
+            return JsonConvert.SerializeObject(this);
+        }
+    }
+}

--- a/Services/Models/DeleteStatus.cs
+++ b/Services/Models/DeleteStatus.cs
@@ -1,9 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
 using Microsoft.Azure.Documents;
 using Newtonsoft.Json;
 
+/**
+ * Stores data for status of delete operation
+ */
 namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services.Models
 {
     public class DeleteStatus
@@ -17,7 +20,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services.Models
         public DateTime? Timestamp { get; set; }
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public int? RecordsLeftToDelete { get; set; }
-        
+
         public DeleteStatus() { }
 
         public DeleteStatus(Document doc)

--- a/Services/Rules.cs
+++ b/Services/Rules.cs
@@ -242,7 +242,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services
             Rule savedRule = null;
             try
             {
-                savedRule = await GetAsync(rule.Id);
+                savedRule = await this.GetAsync(rule.Id);
             }
             catch (ResourceNotFoundException e)
             {
@@ -252,7 +252,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services
 
             if (savedRule == null)
             {
-                return await CreateAsync(rule);
+                return await this.CreateAsync(rule);
             }
 
             rule.DateCreated = savedRule.DateCreated;

--- a/Services/Runtime/AlarmsConfig.cs
+++ b/Services/Runtime/AlarmsConfig.cs
@@ -1,0 +1,23 @@
+﻿namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services.Runtime
+{
+    public class AlarmsConfig
+    {
+        public StorageConfig StorageConfig { get; set; }
+        public int MaxRetries { get; set; }
+        public int DeleteBatchSize { get; set; }
+        public int DeleteIntervalMsec { get; set; }
+
+        public AlarmsConfig(
+            string documentDbDatabase,
+            string documentDbCollection,
+            int maxRetries,
+            int deleteBatchSize,
+            int deleteIntervalMsec)
+        {
+            this.StorageConfig = new StorageConfig(documentDbDatabase, documentDbCollection);
+            this.MaxRetries = maxRetries;
+            this.DeleteBatchSize = deleteBatchSize;
+            this.DeleteIntervalMsec = deleteIntervalMsec;
+        }
+    }
+}

--- a/Services/Runtime/AlarmsConfig.cs
+++ b/Services/Runtime/AlarmsConfig.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services.Runtime
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services.Runtime
 {
     public class AlarmsConfig
     {

--- a/Services/Runtime/ServicesConfig.cs
+++ b/Services/Runtime/ServicesConfig.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services.Runtime
         string StorageAdapterApiUrl { get; set; }
         int StorageAdapterApiTimeout { get; set; }
         StorageConfig MessagesConfig { get; set; }
-        StorageConfig AlarmsConfig { get; set; }
+        AlarmsConfig AlarmsConfig { get; set; }
         string StorageType { get; set; }
         Uri DocumentDbUri { get; }
         string DocumentDbKey { get; }
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services.Runtime
 
         public StorageConfig MessagesConfig { get; set; }
 
-        public StorageConfig AlarmsConfig { get; set; }
+        public AlarmsConfig AlarmsConfig { get; set; }
 
         public string StorageType { get; set; }
 

--- a/Services/StorageClient.cs
+++ b/Services/StorageClient.cs
@@ -11,7 +11,6 @@ using Microsoft.Azure.Documents.SystemFunctions;
 using Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services.Diagnostics;
 using Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services.Exceptions;
 using Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services.Runtime;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services
 {
@@ -38,8 +37,8 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services
             string colId,
             FeedOptions queryOptions,
             string queryString,
-            int skip,
-            int limit);
+            int? skip,
+            int? limit);
 
         int QueryCount(
             string databaseName,
@@ -213,8 +212,8 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services
             string colId,
             FeedOptions queryOptions,
             string queryString,
-            int skip,
-            int limit)
+            int? skip,
+            int? limit)
         {
             if (queryOptions == null)
             {
@@ -233,9 +232,16 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services
                     collectionLink,
                     queryString,
                     queryOptions)
-                .AsEnumerable()
-                .Skip(skip)
-                .Take(limit);
+                .AsEnumerable();
+            if (skip.HasValue)
+            {
+                queryResults = queryResults.Skip(skip.Value);
+            }
+
+            if (limit.HasValue)
+            {
+                queryResults = queryResults.Take(limit.Value);
+            }
 
             foreach (Document doc in queryResults)
             {
@@ -272,7 +278,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services
 
             if (resultList.Length > 0)
             {
-                return (int) resultList[0];
+                return (int)resultList[0];
             }
 
             this.log.Info("No results found for count query", () => new { databaseName, colId, queryString });

--- a/WebService.Test/Controllers/AlarmsByRuleControllerTest.cs
+++ b/WebService.Test/Controllers/AlarmsByRuleControllerTest.cs
@@ -50,8 +50,8 @@ namespace WebService.Test.Controllers
             this.log = new Mock<ILogger>();
 
             this.storage = new StorageClient(servicesConfig, this.log.Object);
-            string dbName = servicesConfig.AlarmsConfig.DocumentDbDatabase;
-            string collName = servicesConfig.AlarmsConfig.DocumentDbCollection;
+            string dbName = servicesConfig.AlarmsConfig.StorageConfig.DocumentDbDatabase;
+            string collName = servicesConfig.AlarmsConfig.StorageConfig.DocumentDbCollection;
             this.storage.CreateCollectionIfNotExistsAsync(dbName, collName);
 
             this.sampleAlarms = this.getSampleAlarms();

--- a/WebService/Runtime/Config.cs
+++ b/WebService/Runtime/Config.cs
@@ -36,6 +36,9 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.Runtime
         private const string ALARMS_DB_KEY = "TelemetryService:Alarms:";
         private const string ALARMS_DB_DATABASE_KEY = ALARMS_DB_KEY + "database";
         private const string ALARMS_DB_COLLECTION_KEY = ALARMS_DB_KEY + "collection";
+        private const string ALARMS_DB_MAX_RETRIES = ALARMS_DB_KEY + "max_retries";
+        private const string ALARMS_DB_DELETE_BATCH_SIZE = ALARMS_DB_KEY + "delete_batch_size";
+        private const string ALARMS_DB_DELETE_INTERVAL_MSEC = ALARMS_DB_KEY + "delete_interval_msec";
 
         private const string STORAGE_ADAPTER_KEY = "StorageAdapterService:";
         private const string STORAGE_ADAPTER_API_URL_KEY = STORAGE_ADAPTER_KEY + "webservice_url";
@@ -65,9 +68,12 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.Runtime
                 MessagesConfig = new StorageConfig(
                     configData.GetString(MESSAGES_DB_DATABASE_KEY),
                     configData.GetString(MESSAGES_DB_COLLECTION_KEY)),
-                AlarmsConfig = new StorageConfig(
+                AlarmsConfig = new AlarmsConfig(
                     configData.GetString(ALARMS_DB_DATABASE_KEY),
-                    configData.GetString(ALARMS_DB_COLLECTION_KEY)),
+                    configData.GetString(ALARMS_DB_COLLECTION_KEY),
+                    configData.GetInt(ALARMS_DB_MAX_RETRIES),
+                    configData.GetInt(ALARMS_DB_DELETE_BATCH_SIZE),
+                    configData.GetInt(ALARMS_DB_DELETE_INTERVAL_MSEC)),
                 StorageType = configData.GetString(STORAGE_TYPE_KEY),
                 DocumentDbConnString = configData.GetString(DOCUMENTDB_CONNSTRING_KEY),
                 DocumentDbThroughput = configData.GetInt(DOCUMENTDB_RUS_KEY),

--- a/WebService/appsettings.ini
+++ b/WebService/appsettings.ini
@@ -22,7 +22,9 @@ collection = "messages"
 [TelemetryService:Alarms]
 database = "pcs-iothub-stream"
 collection = "alarms"
-
+max_retries = 3
+delete_batch_size = 50
+delete_interval_msec = 1000
 
 [StorageAdapterService]
 webservice_url = "${PCS_STORAGEADAPTER_WEBSERVICE_URL}"

--- a/WebService/v1/Controllers/AlarmsByRuleController.cs
+++ b/WebService/v1/Controllers/AlarmsByRuleController.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Controllers
             }
 
             var operationId = Guid.NewGuid();
-            this.alarmService.StartDeleteByRule(id,
+            this.alarmService.StartDeleteByRuleAsync(id,
                     fromDate,
                     toDate,
                     order,
@@ -164,11 +164,11 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Controllers
                     limit,
                     deviceIds,
                     operationId);
-            string body = $"OperationId: {operationId.ToString()}";
+            string body = $"{{\"OperationId\": \"{operationId.ToString()}\"}}";
             var bytes = Encoding.UTF8.GetBytes(body);
             this.Response.StatusCode = 202;
             this.Response.ContentLength = bytes.Length;
-            this.Response.ContentType = "text/plain";
+            this.Response.ContentType = "application/json";
             this.Response.Body.Write(bytes, 0, bytes.Length);
         }
 
@@ -178,7 +178,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.WebService.v1.Controllers
             string status = this.alarmService.GetDeleteByRuleStatus(id);
             var bytes = Encoding.UTF8.GetBytes(status);
             this.Response.ContentLength = bytes.Length;
-            this.Response.ContentType = "text/plain";
+            this.Response.ContentType = "application/json";
             this.Response.Body.Write(bytes, 0, bytes.Length);
         }
     }


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->
Add API call to delete alarms by rule id. API call is POST request (as could have many alarms), which will return an operation id. Can then query for operation status using this id another new API call, GET delete status. Deletes are done in batches of 50 to avoid throttling, and the delete batches will retry 3 times on error (except a not found error, as that means the document was already deleted). 

Sample API calls:
POST .../telemetry/v1/alarmsbyrule/delete/{rule-id}
no headers, no body needed
Response:
202 Accepted
Body: 
{
    "OperationId": "a4eabe7e-dc84-4ab0-9749-0392223a499c"
}

GET .../telemetry/v1/alarmsbyrule/deletestatus/a4eabe7e-dc84-4ab0-9749-0392223a499c
Response:
200 OK
Body:
{
    "id": "a4eabe7e-dc84-4ab0-9749-0392223a499c",
    "Status": "Success",
    "RecordsDeleted": 775,
    "Timestamp": "2018-06-06T18:34:55.9017983Z"
}
**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [x] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
Will update wiki with new API information once merged.