### PR TITLE
Fix Create Rule bug

### DIFF
--- a/Services.Test/RulesTest.cs
+++ b/Services.Test/RulesTest.cs
@@ -288,6 +288,45 @@ namespace Services.Test
             Assert.Equal(newRuleId, rule.Id);
         }
 
+        /**
+        * On creating a new rule, new rule id should be returned
+        */
+        [Fact, Trait(Constants.TYPE, Constants.UNIT_TEST)]
+        public async Task CreateNewRule_ReturnsNewId()
+        {
+            // Arrange
+            Rule test = new Rule
+            {
+                Enabled = true
+            };
+
+            string newRuleId = "TESTRULEID" + DateTime.Now.ToString("yyyyMMddHHmmss");
+            Rule resultRule = new Rule
+            {
+                Enabled = true,
+                Id = newRuleId
+            };
+
+            string ruleString = JsonConvert.SerializeObject(resultRule);
+
+            ValueApiModel result = new ValueApiModel
+            {
+                Data = ruleString,
+                ETag = "1234",
+                Key = newRuleId
+            };
+            
+
+            this.storageAdapter.Setup(x => x.CreateAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(Task.FromResult(result));
+
+            // Act
+            Rule rule = await this.rules.CreateAsync(test);
+
+            // Assert
+            Assert.Equal(newRuleId, rule.Id);
+        }
+
         private void ThereAreNoRulessInStorage()
         {
             this.rulesMock.Setup(x => x.GetListAsync(null, 0, LIMIT, null, false))

--- a/Services/Rules.cs
+++ b/Services/Rules.cs
@@ -251,7 +251,7 @@ namespace Microsoft.Azure.IoTSolutions.DeviceTelemetry.Services
             Rule newRule = this.Deserialize(result.Data);
             newRule.ETag = result.ETag;
 
-            if (newRule.Id == null) newRule.Id = result.Key;
+            if (string.IsNullOrEmpty(newRule.Id)) newRule.Id = result.Key;
 
             return newRule;
         }


### PR DESCRIPTION
# Type of change? <!-- [x] all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

# Description, Context, Motivation <!-- Please help us reviewing your PR -->
Create rule was returning an empty Id because it was checking if the id was null, but the id is an empty string. Change check to fill in id if null or empty.

**Checklist:**

- [x] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
